### PR TITLE
NFC: Minor code cleanup for issues found when building at Google.

### DIFF
--- a/teckyl/MLIRGen.cpp
+++ b/teckyl/MLIRGen.cpp
@@ -6,13 +6,13 @@
 #include <llvm/ADT/ScopedHashTable.h>
 #include <mlir/Dialect/AffineOps/AffineOps.h>
 #include <mlir/Dialect/Linalg/EDSC/Builders.h>
+#include <mlir/Dialect/Linalg/EDSC/Intrinsics.h>
 #include <mlir/Dialect/LoopOps/LoopOps.h>
 #include <mlir/Dialect/StandardOps/Ops.h>
 #include <mlir/IR/AffineExpr.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/Function.h>
 #include <mlir/IR/StandardTypes.h>
-
 #include <tc/lang/sema.h>
 
 namespace teckyl {
@@ -829,7 +829,6 @@ private:
 
     // Build expression for RHS of assignment
     mlir::Value rhsVal = exprGen.buildExpr(c.rhs());
-    mlir::Type rhsType = rhsVal.getType();
     mlir::Value accu = exprGen.buildIndexLoadExpr(c.ident(), c.indices());
     mlir::Value assignmentVal;
 
@@ -1076,7 +1075,7 @@ private:
       }
     }
 
-    return std::move(ranks);
+    return ranks;
   }
 };
 

--- a/teckyl/lang_extras.h
+++ b/teckyl/lang_extras.h
@@ -99,7 +99,7 @@ collectExplicitIteratorBounds(const lang::Comprehension &c) {
     bounds.insert({name, range});
   }
 
-  return std::move(bounds);
+  return bounds;
 }
 
 // Collects the set of parameters from the signature of `def` that

--- a/teckyl/main.cc
+++ b/teckyl/main.cc
@@ -89,7 +89,6 @@ void dumpMLIR(const std::map<std::string, lang::Def>& tcs)
 }
 
 int main(int argc, char **argv) {
-  tc::CompilerOptions options;
   std::map<std::string, lang::Def> tcs;
 
   llvm::cl::ParseCommandLineOptions(argc, argv, "teckyl frontend\n");

--- a/teckyl/tc/lang/builtins.h
+++ b/teckyl/tc/lang/builtins.h
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#pragma once
+#ifndef TECKYL_TC_LANG_BUILTINS_H_
+#define TECKYL_TC_LANG_BUILTINS_H_
 
 #include <unordered_map>
 
@@ -96,3 +97,6 @@ std::unordered_map<std::string, size_t> builtin_functions({
 
 } // namespace
 } // namespace lang
+
+#endif // TECKYL_TC_LANG_BUILTINS_H_
+

--- a/teckyl/tc/lang/error_report.h
+++ b/teckyl/tc/lang/error_report.h
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#pragma once
+#ifndef TECKYL_TC_LANG_ERROR_REPORT_H_
+#define TECKYL_TC_LANG_ERROR_REPORT_H_
 
 #include "tc/lang/tree.h"
 #include "tc/utils/compiler_options.h"
@@ -63,3 +64,6 @@ const ErrorReport& operator<<(const ErrorReport& e, const T& t) {
         << __FILE__ << ":" << __LINE__ << ": assertion failed: " << #cond; \
   }
 } // namespace lang
+
+#endif // TECKYL_TC_LANG_ERROR_REPORT_H_
+

--- a/teckyl/tc/lang/lexer.h
+++ b/teckyl/tc/lang/lexer.h
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#pragma once
+#ifndef TECKYL_TC_LANG_LEXER_H_
+#define TECKYL_TC_LANG_LEXER_H_
+
 #include <assert.h>
 #include <algorithm>
 #include <iostream>
@@ -460,8 +462,7 @@ struct Token {
   std::string numStringValue() {
     assert(TK_NUMBER == kind);
     size_t idx;
-    double r = std::stod(text(), &idx);
-
+    std::stod(text(), &idx);
     assert(idx > 0);
 
     if(idx < range.size()) {
@@ -571,3 +572,5 @@ struct Lexer {
   SharedParserData& shared;
 };
 } // namespace lang
+
+#endif // TECKYL_TC_LANG_LEXER_H_

--- a/teckyl/tc/lang/parser.h
+++ b/teckyl/tc/lang/parser.h
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#pragma once
+#ifndef TECKYL_TC_LANG_PARSER_H_
+#define TECKYL_TC_LANG_PARSER_H_
+
 #include "tc/lang/lexer.h"
 #include "tc/lang/tree.h"
 #include "tc/lang/tree_views.h"
@@ -349,3 +351,6 @@ struct Parser {
   SharedParserData& shared;
 };
 } // namespace lang
+
+#endif // TECKYL_TC_LANG_PARSER_H_
+

--- a/teckyl/tc/lang/sema.h
+++ b/teckyl/tc/lang/sema.h
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#pragma once
+#ifndef TECKYL_TC_SEMA_H_
+#define TECKYL_TC_SEMA_H_
 
 #include <unordered_set>
 
@@ -719,3 +720,6 @@ struct Sema {
   tc::CompilerOptions compilerOptions;
 };
 } // namespace lang
+
+#endif // TECKYL_TC_SEMA_H_
+

--- a/teckyl/tc/lang/tree.h
+++ b/teckyl/tc/lang/tree.h
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#pragma once
+#ifndef TECKYL_TC_LANG_TREE_H_
+#define TECKYL_TC_LANG_TREE_H_
 
 #include <functional>
 #include <memory>
@@ -126,8 +127,8 @@ struct String : public Tree {
   std::string value_;
 };
 struct Number : public Tree {
-  Number(const std::string& value_, const std::string& suffix) :
-    Tree(TK_NUMBER), value_(value_), suffix_(suffix_) {}
+  Number(const std::string& value, const std::string& suffix) :
+    Tree(TK_NUMBER), value_(value), suffix_(suffix) {}
   virtual const std::string& numValue() const override {
     return value_;
   }
@@ -288,3 +289,6 @@ static inline std::ostream& operator<<(std::ostream& out, TreeRef t) {
   return out << pretty_tree(t);
 }
 } // namespace lang
+
+#endif // TECKYL_TC_LANG_TREE_H_
+

--- a/teckyl/tc/lang/tree_views.h
+++ b/teckyl/tc/lang/tree_views.h
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#pragma once
+#ifndef TECKYL_TC_LANG_TREE_VIEWS_H_
+#define TECKYL_TC_LANG_TREE_VIEWS_H_
+
 #include "tc/lang/error_report.h"
 #include "tc/lang/tree.h"
 
@@ -469,8 +471,8 @@ struct Const : public TreeView {
   T value() const {
     T res;
     std::istringstream iss(value());
-    bool success = iss >> res;
-    assert(success);
+    iss >> res;
+    assert(!iss.fail());
     return res;
   }
   TreeRef type() const {
@@ -524,3 +526,6 @@ struct Exists : public TreeView {
 };
 
 } // namespace lang
+
+#endif // TECKYL_TC_LANG_TREE_VIEWS_H_
+

--- a/teckyl/tc/utils/compiler_options.h
+++ b/teckyl/tc/utils/compiler_options.h
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#pragma once
+#ifndef TECKYL_TC_UTILS_COMPILER_OPTIONS_H_
+#define TECKYL_TC_UTILS_COMPILER_OPTIONS_H_
 
 namespace tc {
 
@@ -37,3 +38,5 @@ class CompilerOptions {
 };
 
 } // namespace tc
+
+#endif // TECKYL_TC_UTILS_COMPILER_OPTIONS_H_


### PR DESCRIPTION
* Some unused variables removed.
* Replace #pragma once with header guards in tc code (#pragma once interacts badly with some strategies for managing include directories).
* Fix an uninitialized member access.