### PR TITLE
Normalize include paths

### DIFF
--- a/teckyl/CMakeLists.txt
+++ b/teckyl/CMakeLists.txt
@@ -26,7 +26,7 @@ add_llvm_executable(teckyl
 target_compile_options(teckyl PRIVATE -fexceptions -fno-rtti)
 
 target_include_directories(teckyl PRIVATE
-  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${CMAKE_CURRENT_SOURCE_DIR}/..
   "${CMAKE_SOURCE_DIR}/llvm-project/mlir/include"
   "${CMAKE_SOURCE_DIR}/llvm-project/llvm/include"
   "${CMAKE_BINARY_DIR}/llvm-project/mlir/include"

--- a/teckyl/MLIRAffineExprGen.h
+++ b/teckyl/MLIRAffineExprGen.h
@@ -1,8 +1,8 @@
 #ifndef TECKYL_MLIRAFFINEEXPRGEN_H
 #define TECKYL_MLIRAFFINEEXPRGEN_H
 
-#include "Exception.h"
-#include "lang_extras.h"
+#include "teckyl/Exception.h"
+#include "teckyl/lang_extras.h"
 
 #include <mlir/IR/AffineExpr.h>
 

--- a/teckyl/MLIRGen.cpp
+++ b/teckyl/MLIRGen.cpp
@@ -1,7 +1,7 @@
-#include "MLIRGen.h"
-#include "MLIRAffineExprGen.h"
-#include "lang_affine.h"
-#include "lang_extras.h"
+#include "teckyl/MLIRGen.h"
+#include "teckyl/MLIRAffineExprGen.h"
+#include "teckyl/lang_affine.h"
+#include "teckyl/lang_extras.h"
 
 #include <llvm/ADT/ScopedHashTable.h>
 #include <llvm/Support/ErrorHandling.h>
@@ -14,7 +14,7 @@
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/Function.h>
 #include <mlir/IR/StandardTypes.h>
-#include <tc/lang/sema.h>
+#include "teckyl/tc/lang/sema.h"
 
 namespace teckyl {
 

--- a/teckyl/MLIRGen.h
+++ b/teckyl/MLIRGen.h
@@ -1,10 +1,10 @@
 #ifndef TECKYL_MLIRGEN_H
 #define TECKYL_MLIRGEN_H
 
-#include "Exception.h"
+#include "teckyl/Exception.h"
 
 #include <mlir/IR/Function.h>
-#include <tc/lang/tree_views.h>
+#include "teckyl/tc/lang/tree_views.h"
 
 #include <sstream>
 

--- a/teckyl/lang_affine.h
+++ b/teckyl/lang_affine.h
@@ -1,8 +1,8 @@
 #ifndef TECKYL_LANG_AFFINE_H
 #define TECKYL_LANG_AFFINE_H
 
-#include "Exception.h"
-#include "lang_extras.h"
+#include "teckyl/Exception.h"
+#include "teckyl/lang_extras.h"
 
 #include <set>
 #include <string>

--- a/teckyl/lang_extras.h
+++ b/teckyl/lang_extras.h
@@ -1,8 +1,8 @@
 #ifndef TECKYL_LANG_EXTRAS_H
 #define TECKYL_LANG_EXTRAS_H
 
-#include "Exception.h"
-#include <tc/lang/tree.h>
+#include "teckyl/Exception.h"
+#include "teckyl/tc/lang/tree.h"
 
 #include <map>
 #include <set>

--- a/teckyl/main.cc
+++ b/teckyl/main.cc
@@ -8,9 +8,9 @@
 #include <mlir/Analysis/Verifier.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/Module.h>
-#include <tc/lang/parser.h>
+#include "teckyl/tc/lang/parser.h"
 
-#include "MLIRGen.h"
+#include "teckyl/MLIRGen.h"
 
 // Commandline options
 static llvm::cl::opt<std::string> inputFilename(
@@ -116,7 +116,6 @@ int main(int argc, char **argv) {
   } catch(...) {
     std::cerr << "An unknown error has occured." << std::endl;
     return 1;
-  }  
+  }
 #endif // COMPILE_WITH_EXCEPTIONS
-  
 }

--- a/teckyl/tc/lang/error_report.h
+++ b/teckyl/tc/lang/error_report.h
@@ -16,8 +16,8 @@
 #ifndef TECKYL_TC_LANG_ERROR_REPORT_H_
 #define TECKYL_TC_LANG_ERROR_REPORT_H_
 
-#include "tc/lang/tree.h"
-#include "tc/utils/compiler_options.h"
+#include "teckyl/tc/lang/tree.h"
+#include "teckyl/tc/utils/compiler_options.h"
 
 #ifndef THROW_OR_ASSERT
 #ifdef COMPILE_WITH_EXCEPTIONS

--- a/teckyl/tc/lang/lexer.cc
+++ b/teckyl/tc/lang/lexer.cc
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "tc/lang/lexer.h"
+#include "teckyl/tc/lang/lexer.h"
 
 #include <cstring>
 
-#include "tc/lang/error_report.h"
+#include "teckyl/tc/lang/error_report.h"
 
 namespace lang {
 

--- a/teckyl/tc/lang/parser.cc
+++ b/teckyl/tc/lang/parser.cc
@@ -13,4 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "tc/lang/parser.h"
+#include "teckyl/tc/lang/parser.h"

--- a/teckyl/tc/lang/parser.h
+++ b/teckyl/tc/lang/parser.h
@@ -16,9 +16,9 @@
 #ifndef TECKYL_TC_LANG_PARSER_H_
 #define TECKYL_TC_LANG_PARSER_H_
 
-#include "tc/lang/lexer.h"
-#include "tc/lang/tree.h"
-#include "tc/lang/tree_views.h"
+#include "teckyl/tc/lang/lexer.h"
+#include "teckyl/tc/lang/tree.h"
+#include "teckyl/tc/lang/tree_views.h"
 
 namespace lang {
 

--- a/teckyl/tc/lang/sema.h
+++ b/teckyl/tc/lang/sema.h
@@ -18,11 +18,11 @@
 
 #include <unordered_set>
 
-#include "tc/lang/builtins.h"
-#include "tc/lang/error_report.h"
-#include "tc/lang/tree.h"
-#include "tc/lang/tree_views.h"
-#include "tc/utils/compiler_options.h"
+#include "teckyl/tc/lang/builtins.h"
+#include "teckyl/tc/lang/error_report.h"
+#include "teckyl/tc/lang/tree.h"
+#include "teckyl/tc/lang/tree_views.h"
+#include "teckyl/tc/utils/compiler_options.h"
 
 namespace lang {
 

--- a/teckyl/tc/lang/tree.h
+++ b/teckyl/tc/lang/tree.h
@@ -23,7 +23,7 @@
 
 #include <llvm/ADT/Twine.h>
 #include <llvm/Support/ErrorHandling.h>
-#include "tc/lang/lexer.h"
+#include "teckyl/tc/lang/lexer.h"
 
 using llvm::Twine;
 

--- a/teckyl/tc/lang/tree_views.h
+++ b/teckyl/tc/lang/tree_views.h
@@ -16,8 +16,8 @@
 #ifndef TECKYL_TC_LANG_TREE_VIEWS_H_
 #define TECKYL_TC_LANG_TREE_VIEWS_H_
 
-#include "tc/lang/error_report.h"
-#include "tc/lang/tree.h"
+#include "teckyl/tc/lang/error_report.h"
+#include "teckyl/tc/lang/tree.h"
 
 #include <sstream>
 


### PR DESCRIPTION
This revision normalizes include paths so we always use:
`#include "teckyl/..."`

While we don't have to use the same `include` / `lib` dichotomy,
paths normalization is more consistent with LLVM and MLIR's.
It also follows our internal style more closely.