### PR TITLE
Update LLVM submodule to latest (0c5db3e)

### DIFF
--- a/teckyl/main.cc
+++ b/teckyl/main.cc
@@ -7,9 +7,12 @@
 #include "teckyl/tc/lang/sema.h"
 #include <llvm/Support/CommandLine.h>
 #include <llvm/Support/ErrorHandling.h>
-#include <mlir/Analysis/Verifier.h>
+#include <mlir/IR/Verifier.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/Module.h>
+#include <mlir/Dialect/StandardOps/EDSC/Intrinsics.h>
+#include <mlir/Dialect/Linalg/IR/LinalgOps.h>
+#include "mlir/Dialect/SCF/SCF.h"
 
 #include "teckyl/MLIRGen.h"
 
@@ -65,6 +68,9 @@ void dumpAST(const std::map<std::string, lang::Def> &tcs) {
 //
 // Returns 0 on success or 1 in case of an error.
 void dumpMLIR(const std::map<std::string, lang::Def> &tcs) {
+  mlir::registerDialect<mlir::StandardOpsDialect>();
+  mlir::registerDialect<mlir::linalg::LinalgDialect>();
+  mlir::registerDialect<mlir::scf::SCFDialect>();
   mlir::MLIRContext context;
   mlir::ModuleOp module;
   mlir::OpBuilder builder(&context);


### PR DESCRIPTION
- LoopDialect is now called structured control flow SCF, see:
c25b20c0f6c13d68dbc2e185764082d61ae4a132

- ValueHandle has been retired, see:
367229e100eca714276253bf95a0dd3d084a9624

- Path update for AffineOps.h, see:
e708471395b685f3edec2e8c1ab320358640ae74

- Path update for Verifier.h, see:
57818885be5160380e29e9c2e915b37d5b11ade9

- `getBuilder` ranamed to `getBuilderRef`, see:
0d61dcf606b823c9cee4f16e89a7a0839be4ba36

- Register Linalg, StandardOps, and SCF
dialects.